### PR TITLE
fix: Use the vault repo for centos-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ vagrant up --provider=<your favorite provider>
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.box = "dweomer/centos-8.4-amd64"
+  # deal with the repo due to the EOL of centos-8
+  config.vm.provision :shell, :inline => "
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+  "
   config.vm.provision :k3s, run: "once" do |k3s|
     # installer_url: can be anything that curl can access from the guest
     # default =>`https://get.k3s.io`

--- a/test/centos-8/Vagrantfile
+++ b/test/centos-8/Vagrantfile
@@ -9,6 +9,11 @@ Vagrant.configure("2") do |config|
   config.vm.define 'vagrant-k3s-test', primary: true do |node|
     node.vm.box = 'dweomer/centos-8.4-amd64'
     node.vm.hostname = 'vagrant'
+    # deal with the repo due to the EOL of centos-8
+    node.vm.provision :shell, :inline => "
+      sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+      sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+    "
     node.vm.provision :k3s, run: "once" do |k3s|
       k3s.args = %w[server --selinux]
       k3s.env = %w[


### PR DESCRIPTION
Since the previous repository is unavailable due to the EOL of CentOS 8, the Vagrantfiles related to CentOS 8 would generate errors when running `vagrant up`. This PR is going to use the vault repository which still works.