### PR TITLE
Add support for k3s completion subcommand

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GIT
 PATH
   remote: .
   specs:
-    vagrant-k3s (0.1.8)
+    vagrant-k3s (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/vagrant-k3s/config.rb
+++ b/lib/vagrant-k3s/config.rb
@@ -57,6 +57,10 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :skip_start
 
+      # Defaults to false
+      # @return [Boolean]
+      attr_accessor :skip_complete
+
       # # INSTALL_K3S_BIN_DIR
       # # @return [String]
       # attr_accessor :install_bin_dir
@@ -109,6 +113,7 @@ module VagrantPlugins
         @env_path = UNSET_VALUE
         @installer_url = UNSET_VALUE
         @skip_start = UNSET_VALUE
+        @skip_complete = UNSET_VALUE
       end
 
       def finalize!
@@ -123,6 +128,7 @@ module VagrantPlugins
         @env_path = DEFAULT_ENV_PATH if @env_path == UNSET_VALUE
         @installer_url = DEFAULT_INSTALLER_URL if @installer_url == UNSET_VALUE
         @skip_start = false if @skip_start == UNSET_VALUE
+        @skip_complete = false if @skip_complete == UNSET_VALUE
 
         if @args && args_valid?
           @args = @args.is_a?(Array) ? @args.map { |a| a.to_s } : @args.to_s

--- a/lib/vagrant-k3s/provisioner.rb
+++ b/lib/vagrant-k3s/provisioner.rb
@@ -79,6 +79,18 @@ module VagrantPlugins
           outputs.values.map(&:close)
         end
 
+        if not config.skip_complete
+          outputs, handler = build_outputs
+          begin
+            @machine.ui.info 'Enabling K3s autocompletion ...'
+            @machine.communicate.sudo("k3s completion -i bash", error_key: :ssh_bad_exit_status_muted, &handler)
+          rescue Vagrant::Errors::VagrantError => e
+            @machine.ui.detail "#{e.extra_data[:stderr].chomp}", :color => :yellow
+          ensure
+            outputs.values.map(&:close)
+          end
+        end
+
         begin
           exe = "k3s"
           @machine.ui.info 'Checking the K3s version ...'

--- a/lib/vagrant-k3s/version.rb
+++ b/lib/vagrant-k3s/version.rb
@@ -2,6 +2,6 @@
 
 module VagrantPlugins
   module K3s
-    VERSION = '0.1.9'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

K3s plugin will now automatically add auto completion to the root user. This can be disabled if not using bash. 